### PR TITLE
Feature/t 001 criar mapper dto

### DIFF
--- a/src/main/java/dev/java/x/CadastroDeNinjas/Missoes/MissoesController.java
+++ b/src/main/java/dev/java/x/CadastroDeNinjas/Missoes/MissoesController.java
@@ -18,22 +18,22 @@ public class MissoesController {
     }
 
     @PostMapping("/criar")
-    public MissoesModel criarMissoes(@RequestBody MissoesModel missao){
+    public MissoesDTO criarMissoes(@RequestBody MissoesDTO missao){
         return missoesService.criarMissoes(missao);
     }
 
     @GetMapping("/listar")
-    public List<MissoesModel> listarMissoes(){
+    public List<MissoesDTO> listarMissoes(){
         return missoesService.listarMissoes();
     }
 
     @GetMapping("/listar/{id}")
-    public MissoesModel listarMissoesPorId(@PathVariable Long id){
+    public MissoesDTO listarMissoesPorId(@PathVariable Long id){
         return missoesService.listarMissoesPorId(id);
     }
 
     @PutMapping("/alterar/{id}")
-    public MissoesModel alterarMissaoPorId(@PathVariable Long id, @RequestBody MissoesModel missaoAtualizada){
+    public MissoesDTO alterarMissaoPorId(@PathVariable Long id, @RequestBody MissoesDTO missaoAtualizada){
         return missoesService.alterarMissaoPorId(id,missaoAtualizada);
     }
 

--- a/src/main/java/dev/java/x/CadastroDeNinjas/Missoes/MissoesDTO.java
+++ b/src/main/java/dev/java/x/CadastroDeNinjas/Missoes/MissoesDTO.java
@@ -1,0 +1,19 @@
+package dev.java.x.CadastroDeNinjas.Missoes;
+
+import dev.java.x.CadastroDeNinjas.Ninjas.NinjaModel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MissoesDTO {
+
+    private Long id;
+    private String nome;
+    private String dificuldade;
+    private List<NinjaModel> ninja;
+}

--- a/src/main/java/dev/java/x/CadastroDeNinjas/Missoes/MissoesMapper.java
+++ b/src/main/java/dev/java/x/CadastroDeNinjas/Missoes/MissoesMapper.java
@@ -1,0 +1,33 @@
+package dev.java.x.CadastroDeNinjas.Missoes;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MissoesMapper {
+
+    public MissoesModel map(MissoesDTO missoesDTO){
+
+        MissoesModel missoesModel = new MissoesModel();
+
+        missoesModel.setId(missoesDTO.getId());
+        missoesModel.setNome(missoesDTO.getNome());
+        missoesModel.setDificuldade(missoesDTO.getDificuldade());
+        missoesModel.setNinja(missoesDTO.getNinja());
+
+        return missoesModel;
+
+    }
+
+    public MissoesDTO map (MissoesModel missoesModel){
+
+        MissoesDTO missoesDTO = new MissoesDTO();
+
+        missoesDTO.setId(missoesModel.getId());
+        missoesDTO.setNome(missoesModel.getNome());
+        missoesDTO.setDificuldade(missoesModel.getDificuldade());
+        missoesDTO.setNinja(missoesModel.getNinja());
+
+        return missoesDTO;
+
+    }
+}

--- a/src/main/java/dev/java/x/CadastroDeNinjas/Missoes/MissoesModel.java
+++ b/src/main/java/dev/java/x/CadastroDeNinjas/Missoes/MissoesModel.java
@@ -19,10 +19,13 @@ public class MissoesModel {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
 
+    @Column(name = "nome")
     private String nome;
 
+    @Column(name = "dificuldade")
     private String dificuldade;
 
     @OneToMany(mappedBy = "missoes")

--- a/src/main/java/dev/java/x/CadastroDeNinjas/Missoes/MissoesService.java
+++ b/src/main/java/dev/java/x/CadastroDeNinjas/Missoes/MissoesService.java
@@ -9,33 +9,45 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class MissoesService {
 
     private MissoesRepository missoesRepository;
+    private MissoesMapper missoesMapper;
 
-    public MissoesService(MissoesRepository missoesRepository) {
+    public MissoesService(MissoesRepository missoesRepository, MissoesMapper missoesMapper) {
         this.missoesRepository = missoesRepository;
+        this.missoesMapper = missoesMapper;
     }
 
-    public MissoesModel criarMissoes(MissoesModel missao){
-        return missoesRepository.save(missao);
+    public MissoesDTO criarMissoes(MissoesDTO missoesDTO){
+        MissoesModel missao = missoesMapper.map(missoesDTO);
+        missao = missoesRepository.save(missao);
+        return missoesMapper.map(missao);
     }
 
-    public List<MissoesModel> listarMissoes(){
-        return missoesRepository.findAll();
+    public List<MissoesDTO> listarMissoes(){
+        List<MissoesModel> missoes = missoesRepository.findAll();
+        return missoes.stream()
+                .map(missoesMapper::map)
+                .collect(Collectors.toList());
     }
 
-    public MissoesModel listarMissoesPorId(Long id){
+    public MissoesDTO listarMissoesPorId(Long id){
         Optional<MissoesModel> missoesPorId = missoesRepository.findById(id);
-        return missoesPorId.orElse(null);
+        return missoesPorId.map(missoesMapper::map).orElse(null);
     }
 
-    public MissoesModel alterarMissaoPorId(@PathVariable Long id, MissoesModel missaoAtualizada){
-        if (missoesRepository.existsById(id)){
-            missaoAtualizada.setId(id);
-        }
+    public MissoesDTO alterarMissaoPorId(@PathVariable Long id, MissoesDTO missoesDTO){
+       Optional<MissoesModel> missaoExistente = missoesRepository.findById(id);
+       if (missaoExistente.isPresent()){
+           MissoesModel missaoAtualizada = missoesMapper.map(missoesDTO);
+           missaoAtualizada.setId(id);
+           MissoesModel missaoSalva = missoesRepository.save(missaoAtualizada);
+           return missoesMapper.map(missaoSalva);
+       }
         return null;
     }
 

--- a/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaController.java
+++ b/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaController.java
@@ -18,7 +18,7 @@ public class NinjaController {
 
     // Criar Ninja (CREATE)
     @PostMapping("/criar")
-    public NinjaModel criarNinja(@RequestBody NinjaModel ninja){
+    public NinjaDTO criarNinja(@RequestBody NinjaDTO ninja){
         return ninjaService.criarNinja(ninja);
     }
 

--- a/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaController.java
+++ b/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaController.java
@@ -24,19 +24,19 @@ public class NinjaController {
 
     // Mostrar todos os Ninjas (READ)
     @GetMapping("/listar")
-    public List<NinjaModel> listarNinjas(){
+    public List<NinjaDTO> listarNinjas(){
         return ninjaService.listarNinjas();
     }
 
     // Mostrar Ninja por ID (READ)
     @GetMapping("/listar/{id}")
-    public NinjaModel listarNinjasPorId(@PathVariable Long id){
+    public NinjaDTO listarNinjasPorId(@PathVariable Long id){
         return ninjaService.listarNinjasPorId(id);
     }
 
     // Alterar dados dos Ninjas (UPDATE)
     @PutMapping("/alterar/{id}")
-    public NinjaModel alterarNinjaPorId(@PathVariable Long id, @RequestBody NinjaModel ninjaAtualizado){
+    public NinjaDTO alterarNinjaPorId(@PathVariable Long id, @RequestBody NinjaDTO ninjaAtualizado){
         return ninjaService.alterarNinjaPorId(id,ninjaAtualizado);
     }
 

--- a/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaDTO.java
+++ b/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaDTO.java
@@ -18,5 +18,4 @@ public class NinjaDTO {
     private String rank;
     private MissoesModel missoes;
 
-
 }

--- a/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaDTO.java
+++ b/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaDTO.java
@@ -1,0 +1,4 @@
+package dev.java.x.CadastroDeNinjas.Ninjas;
+
+public class NinjaDTO {
+}

--- a/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaDTO.java
+++ b/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaDTO.java
@@ -1,4 +1,22 @@
 package dev.java.x.CadastroDeNinjas.Ninjas;
 
+import dev.java.x.CadastroDeNinjas.Missoes.MissoesModel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
 public class NinjaDTO {
+
+    private Long id;
+    private String nome;
+    private String email;
+    private String imgUrl;
+    private int idade;
+    private String rank;
+    private MissoesModel missoes;
+
+
 }

--- a/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaMapper.java
+++ b/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaMapper.java
@@ -1,4 +1,37 @@
 package dev.java.x.CadastroDeNinjas.Ninjas;
 
+import org.springframework.stereotype.Component;
+
+@Component
 public class NinjaMapper {
+
+    public NinjaModel map (NinjaDTO ninjaDTO){
+
+        NinjaModel ninjaModel = new NinjaModel();
+        ninjaModel.setId(ninjaDTO.getId());
+        ninjaModel.setNome(ninjaDTO.getNome());
+        ninjaModel.setEmail(ninjaDTO.getEmail());
+        ninjaModel.setIdade(ninjaDTO.getIdade());
+        ninjaModel.setImgUrl(ninjaDTO.getImgUrl());
+        ninjaModel.setRank(ninjaDTO.getRank());
+        ninjaModel.setMissoes(ninjaDTO.getMissoes());
+
+        return ninjaModel;
+    }
+
+
+    public  NinjaDTO map (NinjaModel ninjaModel){
+
+        NinjaDTO ninjaDTO = new NinjaDTO();
+        ninjaDTO.setId(ninjaModel.getId());
+        ninjaDTO.setNome(ninjaModel.getNome());
+        ninjaDTO.setEmail(ninjaModel.getEmail());
+        ninjaDTO.setIdade(ninjaModel.getIdade());
+        ninjaDTO.setImgUrl(ninjaModel.getImgUrl());
+        ninjaDTO.setRank(ninjaModel.getRank());
+        ninjaDTO.setMissoes(ninjaModel.getMissoes());
+
+        return ninjaDTO;
+    }
 }
+

--- a/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaMapper.java
+++ b/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaMapper.java
@@ -1,0 +1,4 @@
+package dev.java.x.CadastroDeNinjas.Ninjas;
+
+public class NinjaMapper {
+}

--- a/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaMapper.java
+++ b/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaMapper.java
@@ -5,9 +5,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class NinjaMapper {
 
-    public NinjaModel map (NinjaDTO ninjaDTO){
+    public NinjaModel map(NinjaDTO ninjaDTO){
 
         NinjaModel ninjaModel = new NinjaModel();
+
         ninjaModel.setId(ninjaDTO.getId());
         ninjaModel.setNome(ninjaDTO.getNome());
         ninjaModel.setEmail(ninjaDTO.getEmail());
@@ -23,6 +24,7 @@ public class NinjaMapper {
     public  NinjaDTO map (NinjaModel ninjaModel){
 
         NinjaDTO ninjaDTO = new NinjaDTO();
+
         ninjaDTO.setId(ninjaModel.getId());
         ninjaDTO.setNome(ninjaModel.getNome());
         ninjaDTO.setEmail(ninjaModel.getEmail());

--- a/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaModel.java
+++ b/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaModel.java
@@ -15,6 +15,7 @@ public class NinjaModel {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
 
     @Column (name = "nome")

--- a/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaService.java
+++ b/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaService.java
@@ -11,13 +11,17 @@ import java.util.Optional;
 public class NinjaService {
 
     private NinjaRepository ninjaRepository;
+    private NinjaMapper ninjaMapper;
 
-    public NinjaService(NinjaRepository ninjaRepository) {
+    public NinjaService(NinjaRepository ninjaRepository, NinjaMapper ninjaMapper) {
         this.ninjaRepository = ninjaRepository;
+        this.ninjaMapper = ninjaMapper;
     }
 
-    public NinjaModel criarNinja(NinjaModel ninja){
-        return ninjaRepository.save(ninja);
+    public NinjaDTO criarNinja(NinjaDTO ninjaDTO){
+        NinjaModel ninja =  ninjaMapper.map(ninjaDTO);
+        ninja = ninjaRepository.save(ninja);
+        return ninjaMapper.map(ninja);
     }
 
     public List<NinjaModel> listarNinjas(){

--- a/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaService.java
+++ b/src/main/java/dev/java/x/CadastroDeNinjas/Ninjas/NinjaService.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 public class NinjaService {
@@ -24,24 +26,30 @@ public class NinjaService {
         return ninjaMapper.map(ninja);
     }
 
-    public List<NinjaModel> listarNinjas(){
-        return ninjaRepository.findAll();
+    public List<NinjaDTO> listarNinjas(){
+        List<NinjaModel> ninjas = ninjaRepository.findAll();
+        return ninjas.stream()
+                .map(ninjaMapper::map)
+                .collect(Collectors.toList());
     }
 
-    public NinjaModel listarNinjasPorId(Long id){
-        Optional<NinjaModel>  ninjaPorId = ninjaRepository.findById(id);
-        return ninjaPorId.orElse(null);
+    public NinjaDTO listarNinjasPorId(Long id){
+        Optional<NinjaModel> ninjaPorId = ninjaRepository.findById(id);
+        return ninjaPorId.map(ninjaMapper::map).orElse(null);
     }
 
-    public NinjaModel alterarNinjaPorId(Long id, NinjaModel ninjaAtualizado){
-        if (ninjaRepository.existsById(id)){
+    public NinjaDTO alterarNinjaPorId(Long id, NinjaDTO ninjaDTO){
+        Optional<NinjaModel> ninjaExistente = ninjaRepository.findById(id);
+        if (ninjaExistente.isPresent()){
+            NinjaModel ninjaAtualizado = ninjaMapper.map(ninjaDTO);
             ninjaAtualizado.setId(id);
-            return ninjaRepository.save(ninjaAtualizado);
+            NinjaModel ninjaSalvo = ninjaRepository.save(ninjaAtualizado);
+            return ninjaMapper.map(ninjaSalvo);
         }
         return null;
     }
 
-    public void  deletarNinjaPorId(Long id){
+    public void deletarNinjaPorId(Long id){
         ninjaRepository.deleteById(id);
     }
 }


### PR DESCRIPTION
Alterações propostas pelo PR

Implementação do padrão DTO para as entidades Ninja e Missões, visando eliminar a exposição direta dos modelos de persistência (Entity/Model) na camada de API.

Implementação do NinjaDTO e MissoesDTO para controle dos campos expostos.
Implementação de Mappers para conversão bidirecional entre Model e DTO.
Refatoração integral das camadas de Service e Controller, garantindo que a lógica de negócio e os endpoints operem exclusivamente com DTOs.

Essas mudanças visam melhorar a organização do código e a separação de responsabilidades, facilitando a manutenção e expansão futura da aplicação.